### PR TITLE
Fix getTeamAndUserFromURL function

### DIFF
--- a/github/resource_github_team_membership.go
+++ b/github/resource_github_team_membership.go
@@ -145,7 +145,7 @@ func getTeamAndUserFromURL(url *string) (string, string) {
 
 	urlSlice := strings.Split(*url, "/")
 	for v := range urlSlice {
-		if urlSlice[v] == "teams" {
+		if urlSlice[v] == "teams" || urlSlice[v] == "team" {
 			team = urlSlice[v+1]
 		}
 		if urlSlice[v] == "memberships" {


### PR DESCRIPTION
## WHAT

Fixes the getTeamAndUserFromURL function

## WHY

Inspired by https://github.com/terraform-providers/terraform-provider-github/pull/326. Temporary fix before official provider gets this change merged upstream.